### PR TITLE
add spacing to the 'enter filename' prompt

### DIFF
--- a/lua/api.lua
+++ b/lua/api.lua
@@ -60,7 +60,7 @@ M.scratch = function()
 end
 
 M.scratchWithName = function()
-	vim.ui.input({ prompt = "Enter the file name" }, function(filename)
+	vim.ui.input({ prompt = "Enter the file name: " }, function(filename)
 		createScratchFile(nil, filename)
 	end)
 end


### PR DESCRIPTION
I simply changed `Enter the filename` to `Enter the filename: `.
 
<img width="194" alt="Screen Shot 2022-11-04 at 6 48 06 PM" src="https://user-images.githubusercontent.com/3304073/200095748-ff67b2a0-10aa-43b1-8659-561df6ab9c33.png">
