### PR TITLE
Fix: Initialize config directory before reading config file

### DIFF
--- a/lua/api.lua
+++ b/lua/api.lua
@@ -1,6 +1,7 @@
 local M = {}
 
-local configFilePath = vim.fn.stdpath("cache") .. "/scratch.nvim/" .. "config.json"
+local configDir      = vim.fn.stdpath("cache") .. "/scratch.nvim/"
+local configFilePath = configDir .. "config.json"
 
 local default_config = {
     scratch_file_dir = vim.fn.stdpath("cache") .. "/scratch.nvim",
@@ -19,8 +20,16 @@ local default_config = {
     }
 }
 
+-- Create the config directory if not exist.
+local initConfigDir = function()
+    if vim.fn.isdirectory(configDir) == 0 then
+        vim.fn.mkdir(configDir, "p")
+    end
+end
+
 -- Read json file and parse to dictionary
 local function getConfig()
+    initConfigDir()
     -- write file if the file is not exist
     if vim.fn.filereadable(configFilePath) == 0 then
         local file = io.open(configFilePath, "w")
@@ -45,12 +54,12 @@ local function getScratchFileDir()
     end
 end
 
+
 local initDir = function()
     if vim.fn.isdirectory(getScratchFileDir()) == 0 then
         vim.fn.mkdir(getScratchFileDir(), "p")
     end
 end
-
 
 -- open the config write in nvim current buffer
 local function editConfig()


### PR DESCRIPTION
When you first install the plugin, nvim may complain when trying to read teh config file if the config directory has not been created yet.

```
vim/_editor.lua:0: /Users/carlfurrow/workspace/dotfiles/nvim-configs/basic/init.lua..nvim_exec2() called at /Users/carlfurrow/workspace/dotfiles/nvim-configs/basic/init.lua:0../Users/carlfurrow/.local/share/nvim-basic/lazy/scratch.nvim/plugin/scratch_plug
in.lua: Vim(source):E5113: Error while calling lua chunk: ...rlfurrow/.local/share/nvim/lazy/scratch.nvim/lua/api.lua:27: attempt to index local 'file' (a nil value)
stack traceback:
^I...rlfurrow/.local/share/nvim/lazy/scratch.nvim/lua/api.lua:27: in function 'getConfig'
^I...rlfurrow/.local/share/nvim/lazy/scratch.nvim/lua/api.lua:36: in main chunk
```

This PR adds a new method to initialize the config directory before trying to load the configuration file.
