### PR TITLE
feat: configure window position

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ NOTE: you can't have comment in your config, since only plain json supported rig
 ```jsonc
 {
   "filetypes": ["xml", "go", "lua", "js", "py", "sh"], // you can simply put filetype here
+	"window_cmd": "edit", -- 'vsplit' | 'split' | 'edit' | 'tabedit' | 'rightbelow vsplit'. Can use rightbelow or topleft etc. as modifier
   "scratch_file_dir": "/you_home_path/.cache/nvim/scratch.nvim",
   "filetype_details": {
     "go": {

--- a/lua/scratch/config.lua
+++ b/lua/scratch/config.lua
@@ -24,7 +24,7 @@ end
 
 local default_config = {
 	scratch_file_dir = vim.fn.stdpath("cache") .. "/scratch.nvim",
-	window_pos = "edit", -- 'vsplit' | 'split' | 'edit'
+	window_cmd = "edit", -- 'vsplit' | 'split' | 'edit' | 'tabedit' | 'rightbelow vsplit'
 	filetypes = { "xml", "go", "lua", "js", "py", "sh" }, -- you can simply put filetype here
 	filetype_details = { -- or, you can have more control here
 		json = {}, -- empty table is fine

--- a/lua/scratch/config.lua
+++ b/lua/scratch/config.lua
@@ -24,6 +24,7 @@ end
 
 local default_config = {
 	scratch_file_dir = vim.fn.stdpath("cache") .. "/scratch.nvim",
+	window_pos = "edit", -- 'vsplit' | 'split' | 'edit'
 	filetypes = { "xml", "go", "lua", "js", "py", "sh" }, -- you can simply put filetype here
 	filetype_details = { -- or, you can have more control here
 		json = {}, -- empty table is fine

--- a/lua/scratch/scratch_file.lua
+++ b/lua/scratch/scratch_file.lua
@@ -2,6 +2,11 @@ local M = {}
 local config = require("scratch.config")
 local utils = require("scratch.utils")
 
+local function editFile(fullpath)
+  local config_data = config.getConfig()
+  vim.api.nvim_command(config_data.window_cmd .. " " .. fullpath)
+end
+
 local function write_lines_to_buffer(lines)
 	local bufnr = vim.api.nvim_get_current_buf()
 	vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
@@ -28,7 +33,7 @@ function M.createScratchFileByName(filename)
 	utils.initDir(scratch_file_dir)
 
 	local fullpath = scratch_file_dir .. "/" .. filename
-	vim.api.nvim_command(config_data.window_pos .. fullpath)
+  editFile(fullpath)
 end
 
 local function registerLocalKey()
@@ -57,7 +62,7 @@ function M.createScratchFileByType(ft)
 	end
 
 	local fullpath = utils.genFilepath(config.getConfigFilename(ft), parentDir, config.getConfigRequiresDir(ft))
-	vim.api.nvim_command(config_data.window_pos .. fullpath)
+  editFile(fullpath)
 
 	registerLocalKey()
 
@@ -139,7 +144,7 @@ function M.scratchPad(mode, startLine, endLine)
 	-- TODO: config the pad path
 	local padPath = config_data.pad_path or config_data.scratch_file_dir .. "/scratchPad.md"
 	-- TODO: config: pad open in split or current window or float window
-	vim.api.nvim_command(config_data.window_pos .. padPath)
+  editFile(padPath)
 	vim.api.nvim_win_set_cursor(0, { 1, 0 })
 
 	vim.api.nvim_put(content, "", false, true)
@@ -174,7 +179,7 @@ function M.openScratch()
 		end,
 	}, function(chosenFile)
 		if chosenFile then
-			vim.api.nvim_command(config_data.window_pos .. scratch_file_dir .. "/" .. chosenFile)
+      editFile(scratch_file_dir .. "/" .. chosenFile)
 			registerLocalKey()
 		end
 	end)

--- a/lua/scratch/scratch_file.lua
+++ b/lua/scratch/scratch_file.lua
@@ -28,7 +28,7 @@ function M.createScratchFileByName(filename)
 	utils.initDir(scratch_file_dir)
 
 	local fullpath = scratch_file_dir .. "/" .. filename
-	vim.cmd(":e " .. fullpath)
+	vim.api.nvim_command(config_data.window_pos .. fullpath)
 end
 
 local function registerLocalKey()
@@ -57,7 +57,7 @@ function M.createScratchFileByType(ft)
 	end
 
 	local fullpath = utils.genFilepath(config.getConfigFilename(ft), parentDir, config.getConfigRequiresDir(ft))
-	vim.cmd(":e " .. fullpath)
+	vim.api.nvim_command(config_data.window_pos .. fullpath)
 
 	registerLocalKey()
 
@@ -139,7 +139,7 @@ function M.scratchPad(mode, startLine, endLine)
 	-- TODO: config the pad path
 	local padPath = config_data.pad_path or config_data.scratch_file_dir .. "/scratchPad.md"
 	-- TODO: config: pad open in split or current window or float window
-	vim.cmd("vsplit " .. padPath)
+	vim.api.nvim_command(config_data.window_pos .. padPath)
 	vim.api.nvim_win_set_cursor(0, { 1, 0 })
 
 	vim.api.nvim_put(content, "", false, true)
@@ -174,7 +174,7 @@ function M.openScratch()
 		end,
 	}, function(chosenFile)
 		if chosenFile then
-			vim.cmd(":e " .. scratch_file_dir .. "/" .. chosenFile)
+			vim.api.nvim_command(config_data.window_pos .. scratch_file_dir .. "/" .. chosenFile)
 			registerLocalKey()
 		end
 	end)


### PR DESCRIPTION
Hello there. Hope you're doing well. Thank you for creating this handy scratchpad plugin.

This is a very simple PR to configure the scratchpad window position. My preference is to open it with `vsplit` such that I can reference it side-by-side.

I noticed the comment to also support opening in a floating window, but calculating the floating position is more involved so I didn't do it.

The default `window_pos` is still `edit` to avoid surprises to the users.

Thank you!