### PR TITLE
Add telescope check and add delete map for `ScratchOpenFzf`

### DIFF
--- a/lua/scratch/scratch_file.lua
+++ b/lua/scratch/scratch_file.lua
@@ -192,10 +192,35 @@ function M.openScratch()
 end
 
 function M.fzfScratch()
+  local status, tp = pcall(require, "telescope.builtin")
+  if not status then
+    vim.notify("ScrachOpenFzf needs telescope.nvim")
+    return
+  end
+  --
   local config_data = config.getConfig()
   local scratch_file_dir = config_data.scratch_file_dir
-  require("telescope.builtin").live_grep({
+  local action_state = require("telescope.actions.state")
+
+  local function delete_item(name)
+    vim.fn.system({ "rm", "-rf", scratch_file_dir .. utils.Slash() .. name })
+    vim.notify("delete file " .. name)
+  end
+
+  tp.find_files({
     cwd = scratch_file_dir,
+    attach_mappings = function(prompt_bufnr, map)
+      local picker = action_state.get_current_picker(prompt_bufnr)
+      map("n", "dd", function()
+        picker:delete_selection(function(s)
+          delete_item(s[1])
+          -- vim.print(s)
+          return true
+        end)
+      end)
+
+      return true
+    end,
   })
 end
 

--- a/lua/scratch/scratch_file.lua
+++ b/lua/scratch/scratch_file.lua
@@ -205,33 +205,53 @@ function M.fzfScratch()
   -- if telescope loaded, plenary loaded.
   local job = require("plenary.job")
 
+  local function run_and_get_ret(cmd)
+    local ret = true
+    job
+      :new({
+        command = cmd[1],
+        args = vim.list_slice(cmd, 2, #cmd),
+        on_exit = function(_, exit_code)
+          if exit_code ~= 0 then
+            ret = false
+            return
+          end
+        end,
+      })
+      :sync()
+    return ret
+  end
+
+  -- cur: /desktop/
+  -- paths: a/b/main.go
+  -- delete /desktop/a/b/main.go -> /desktop/a/b (if b is empty) -> /desktop/a (if a is empty)
+  local function delete_recursive(i, cur, paths)
+    if i == vim.tbl_count(paths) + 1 then
+      return
+    end
+
+    cur = cur .. utils.Slash() .. paths[i]
+    delete_recursive(i + 1, cur, paths)
+
+    local cmd = {}
+    if vim.fn.isdirectory(cur) == 0 then -- file
+      cmd = { "rm", cur }
+    else -- dir
+      cmd = { "rmdir", cur }
+    end
+
+    local ret = run_and_get_ret(cmd)
+    if ret then
+      vim.notify("Scratch: delete " .. cur .. " successfully", vim.log.levels.INFO)
+    end
+  end
+
   local function delete_item(picker)
     picker:delete_selection(function(s)
-      local path = vim.fn.split(s[1], utils.Slash())
-      -- delete the first dir/file entry
-      local delete_item_name = path[1]
-      local cmd = { "rm", "-rf", scratch_file_dir .. utils.Slash() .. delete_item_name }
-      local ret = true
-      job
-        :new({
-          command = cmd[1],
-          args = vim.list_slice(cmd, 2, #cmd),
-          on_exit = function(_, exit_code)
-            if exit_code ~= 0 then
-              ret = false
-              return
-            end
-          end,
-        })
-        :sync()
+      local paths = vim.fn.split(s[1], utils.Slash())
+      delete_recursive(1, scratch_file_dir, paths)
 
-      if ret then
-        vim.notify("Scratch: delete " .. s[1] .. " successfully", vim.log.levels.INFO)
-      else
-        vim.notify("Scratch: delete " .. s[1] .. " failed", vim.log.levels.ERROR)
-      end
-
-      return ret
+      return true
     end)
   end
 


### PR DESCRIPTION
This pr contains:
1. code format:  format some weird files
2. add telescope check to avoid errors while running `ScratchOpenFzf` without `telescope`
3. add delete map: sometimes we want delete the previous files in the prompt.


https://github.com/LintaoAmons/scratch.nvim/assets/39361033/72f2f511-2b31-4126-b189-8d07ecb6ff60

