### PR TITLE
Remove files elegantly and support Windows

### DIFF
--- a/lua/scratch/scratch_file.lua
+++ b/lua/scratch/scratch_file.lua
@@ -2,6 +2,7 @@ local M = {}
 local config = require("scratch.config")
 local slash = require("scratch.utils").Slash()
 local utils = require("scratch.utils")
+local telescope_status, telescope_builtin = pcall(require, "telescope.builtin")
 
 local function editFile(fullpath)
   local config_data = config.getConfig()
@@ -170,10 +171,9 @@ function M.scratchWithName()
 end
 
 local function open_scratch_telescope()
-  local status, telescope_builtin = pcall(require, "telescope.builtin")
-  if not status then
+  if not telescope_status then
     vim.notify(
-      'ScrachOpenFzf needs telescope.nvim or you can add `"use_telescope: false"` into your config file'
+      'ScrachOpen needs telescope.nvim or you can just add `"use_telescope: false"` into your config file ot use native select ui'
     )
     return
   end
@@ -224,9 +224,14 @@ function M.openScratch()
 end
 
 function M.fzfScratch()
+  if not telescope_status then
+    vim.notify("ScrachOpenFzf needs telescope.nvim")
+    return
+  end
+
   local config_data = config.getConfig()
   local scratch_file_dir = config_data.scratch_file_dir
-  require("telescope.builtin").live_grep({
+  telescope_builtin.live_grep({
     cwd = scratch_file_dir,
   })
 end

--- a/lua/scratch/telescope_actions.lua
+++ b/lua/scratch/telescope_actions.lua
@@ -24,9 +24,15 @@ function M.delete_item(prompt_bufnr)
 
   local picker = action_state.get_current_picker(prompt_bufnr)
   picker:delete_selection(function(s)
+    local file_name = s[1]
+    -- INFO: currently just protect configFilePath from being removed
+    if file_name == "configFilePath" then
+      vim.notify("[scratch.nvim] configFilePath cannot be removed", vim.log.levels.WARN)
+      return false
+    end
     local config_data = config.getConfig()
     local scratch_file_dir = config_data.scratch_file_dir
-    local p = Path:new({ scratch_file_dir, s[1], sep = utils.Slash() })
+    local p = Path:new({ scratch_file_dir, file_name, sep = utils.Slash() })
     return _delelte(p)
   end)
 end

--- a/lua/scratch/telescope_actions.lua
+++ b/lua/scratch/telescope_actions.lua
@@ -1,64 +1,33 @@
 local M = {}
 
+local action_state = require("telescope.actions.state")
+local Path = require("plenary").path
 local config = require("scratch.config")
 local utils = require("scratch.utils")
-local action_state = require("telescope.actions.state")
-
--- if telescope loaded, plenary loaded.
-local job = require("plenary.job")
-
-local function run_and_get_ret(cmd)
-  local ret = true
-  job
-    :new({
-      command = cmd[1],
-      args = vim.list_slice(cmd, 2, #cmd),
-      on_exit = function(_, exit_code)
-        if exit_code ~= 0 then
-          ret = false
-          return
-        end
-      end,
-    })
-    :sync()
-  return ret
-end
-
--- cur: /desktop/
--- paths: a/b/main.go
--- delete /desktop/a/b/main.go -> /desktop/a/b (if b is empty) -> /desktop/a (if a is empty)
-local function delete_recursive(i, cur, paths)
-  if i == vim.tbl_count(paths) + 1 then
-    return
-  end
-
-  cur = cur .. utils.Slash() .. paths[i]
-  delete_recursive(i + 1, cur, paths)
-
-  local cmd = {}
-  if vim.fn.isdirectory(cur) == 0 then -- file
-    cmd = { "rm", cur }
-  else -- dir
-    cmd = { "rmdir", cur }
-  end
-
-  local ret = run_and_get_ret(cmd)
-  if ret then
-    vim.notify("Scratch: delete " .. cur .. " successfully", vim.log.levels.INFO)
-  end
-end
 
 -- TODO: register buffer local key
 function M.delete_item(prompt_bufnr)
+  local _delelte = function(p)
+    local flag = false
+    while p:exists() do
+      local f = os.remove(p.filename)
+      if f then
+        flag = true
+        vim.notify("delete " .. p.filename)
+      else
+        break
+      end
+      p = p:parent()
+    end
+    return flag
+  end
+
   local picker = action_state.get_current_picker(prompt_bufnr)
   picker:delete_selection(function(s)
     local config_data = config.getConfig()
     local scratch_file_dir = config_data.scratch_file_dir
-    local paths = vim.fn.split(s[1], utils.Slash())
-
-    delete_recursive(1, scratch_file_dir, paths)
-
-    return true
+    local p = Path:new({ scratch_file_dir, s[1], sep = utils.Slash() })
+    return _delelte(p)
   end)
 end
 


### PR DESCRIPTION
Hey, I find one easy and elegant way to remove files and it should support Windows.

Instead of  Unix command `rm/rmdir`,  `os.remove` should support Windows.

=======

And `ScratchOpenFzf` needs `telescope` check also.