### PR TITLE
fix: ScratchWithName empty input error

### DIFF
--- a/lua/scratch/scratch_file.lua
+++ b/lua/scratch/scratch_file.lua
@@ -163,7 +163,9 @@ function M.scratchWithName()
   vim.ui.input({
     prompt = "Enter the file name: ",
   }, function(filename)
-    M.createScratchFileByName(filename)
+    if filename ~= nil and filename ~= "" then
+      M.createScratchFileByName(filename)
+    end
   end)
 end
 


### PR DESCRIPTION
`ScratchWithName` complains with an empty filename