### PR TITLE
Moving away from hard-coding the user's home directory path

### DIFF
--- a/lua/scratch/config.lua
+++ b/lua/scratch/config.lua
@@ -29,7 +29,7 @@ end
 
 -- TODO: #21 allow Lua configuration at the same time
 local default_config = {
-  scratch_file_dir = vim.fn.stdpath("cache") .. slash .. "scratch.nvim",
+  scratch_file_dir = vim.fn.stdpath("cache"):gsub(vim.env.HOME, '~') .. slash .. "scratch.nvim",
   window_cmd = "edit", -- 'vsplit' | 'split' | 'edit' | 'tabedit' | 'rightbelow vsplit'
   use_telescope = true,
   filetypes = { "xml", "go", "lua", "js", "py", "sh" }, -- you can simply put filetype here

--- a/lua/scratch/scratch_file.lua
+++ b/lua/scratch/scratch_file.lua
@@ -4,6 +4,11 @@ local slash = require("scratch.utils").Slash()
 local utils = require("scratch.utils")
 local telescope_status, telescope_builtin = pcall(require, "telescope.builtin")
 
+local expandPath = function(filepath)
+  -- replace ~ with home-directory.
+  return filepath:gsub("^~", vim.env.HOME)
+end
+
 local function editFile(fullpath)
   local config_data = config.getConfig()
   local cmd = config_data.window_cmd or "edit"
@@ -32,7 +37,7 @@ end
 ---@param filename string
 function M.createScratchFileByName(filename)
   local config_data = config.getConfig()
-  local scratch_file_dir = config_data.scratch_file_dir
+  local scratch_file_dir = expandPath(config_data.scratch_file_dir)
   utils.initDir(scratch_file_dir)
 
   local fullpath = scratch_file_dir .. slash .. filename
@@ -55,7 +60,7 @@ end
 ---@param ft string
 function M.createScratchFileByType(ft)
   local config_data = config.getConfig()
-  local parentDir = config_data.scratch_file_dir
+  local parentDir = expandPath(config_data.scratch_file_dir)
   utils.initDir(parentDir)
 
   local subdir = config.getConfigSubDir(ft)
@@ -116,7 +121,7 @@ end
 
 local function getScratchFiles()
   local config_data = config.getConfig()
-  local scratch_file_dir = config_data.scratch_file_dir
+  local scratch_file_dir = expandPath(config_data.scratch_file_dir)
   local res = {}
   res = utils.listDirectoryRecursive(scratch_file_dir)
   for i, str in ipairs(res) do
@@ -148,7 +153,7 @@ function M.scratchPad(mode, startLine, endLine)
 
   local config_data = config.getConfig()
   -- TODO: config the pad path
-  local padPath = config_data.pad_path or config_data.scratch_file_dir .. slash .. "scratchPad.md"
+  local padPath = config_data.pad_path or expandPath(config_data.scratch_file_dir) .. slash .. "scratchPad.md"
   -- TODO: config: pad open in split or current window or float window
   editFile(padPath)
   vim.api.nvim_win_set_cursor(0, { 1, 0 })
@@ -179,7 +184,7 @@ local function open_scratch_telescope()
   end
 
   telescope_builtin.find_files({
-    cwd = config.getConfig().scratch_file_dir,
+    cwd = expandPath(config.getConfig().scratch_file_dir),
     attach_mappings = function(prompt_bufnr, map)
       -- TODO: user can customise keybinding
       map("n", "dd", function()
@@ -194,7 +199,7 @@ end
 local function open_scratch_vim_ui()
   local files = getScratchFiles()
   local config_data = config.getConfig()
-  local scratch_file_dir = config_data.scratch_file_dir
+  local scratch_file_dir = expandPath(config_data.scratch_file_dir)
 
   -- sort the files by their last modified time in descending order
   table.sort(files, function(a, b)
@@ -230,7 +235,7 @@ function M.fzfScratch()
   end
 
   local config_data = config.getConfig()
-  local scratch_file_dir = config_data.scratch_file_dir
+  local scratch_file_dir = expandPath(config_data.scratch_file_dir)
   telescope_builtin.live_grep({
     cwd = scratch_file_dir,
   })


### PR DESCRIPTION
Having the user's home directory path as an absolute reference point for the `scratch_file_dir` cancels out any portability that can be leveraged for machines that have different user names.

Here, we're simply replacing the user's home directory with a `~` when creating the config file and consequently expanding the `~` to the user's home directory when referencing the `scratch_file_dir` key.