### PR TITLE
feat: snacks multi-mode picker and internal cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ return {
   "LintaoAmons/scratch.nvim",
   event = "VeryLazy",
   dependencies = {
-    {"ibhagwan/fzf-lua"}, --optional: if you want to use fzf-lua to pick scratch file. Recommanded, since it will order the files by modification datetime desc. (require rg)
+    {"ibhagwan/fzf-lua"}, --optional: if you want to use fzf-lua to pick scratch file. Recommended, since it will order the files by modification datetime desc. (require rg)
     {"nvim-telescope/telescope.nvim"}, -- optional: if you want to pick scratch file by telescope
     {"folke/snacks.nvim"}, -- optional: if you want to pick scratch file by snacks picker
     {"stevearc/dressing.nvim"} -- optional: to have the same UI shown in the GIF
@@ -32,10 +32,9 @@ return {
   config = function()
     require("scratch").setup({
       scratch_file_dir = vim.fn.stdpath("cache") .. "/scratch.nvim", -- where your scratch files will be put
-      window_cmd = "rightbelow vsplit", -- 'vsplit' | 'split' | 'edit' | 'tabedit' | 'rightbelow vsplit'
-      use_telescope = true,
-      -- fzf-lua is recommanded, since it will order the files by modification datetime desc. (require rg)
-      -- snacks.nvim is also supported as an alternative picker (require rg)
+      window_cmd = "edit", -- 'vsplit' | 'split' | 'edit' | 'tabedit' | 'rightbelow vsplit'
+      -- fzf-lua is recommended, since it will order the files by modification datetime desc. (require rg)
+      -- snacks.nvim is also supported with files/grep/multi mode toggle (require rg)
       file_picker = "fzflua", -- "fzflua" | "telescope" | "snacks" | nil
       filetypes = { "lua", "js", "sh", "ts" }, -- you can simply put filetype here
       filetype_details = { -- or, you can have more control here
@@ -45,8 +44,8 @@ return {
         },
         ["yaml"] = {},
         go = {
-          requireDir = true, -- true if each scratch file requires a new directory
-          filename = "main", -- the filename of the scratch file in the new directory
+          subdir = "unique", -- isolate each scratch file in its own subdirectory
+          filename = "main", -- the filename of the scratch file in the subdirectory
           content = { "package main", "", "func main() {", "  ", "}" },
           cursor = {
             location = { 4, 2 },
@@ -66,6 +65,11 @@ return {
           },
         },
       },
+      picker_keys = {
+        delete = "<C-x>",      -- key to delete a scratch file from the picker
+        toggle_mode = "<C-f>", -- toggle between files/grep/multi (snacks only)
+      },
+      picker_snacks_multi = false, -- true to start snacks picker in multi mode
       hooks = {
         {
           callback = function()
@@ -85,11 +89,11 @@ To check your current configuration, simply type `:lua = vim.g.scratch_config`
 
 And if you want to modify the config, for example add a new filetype, just call the `setup` function with your updated config again.
 
-Or you can change the `vim.g.scratch_config` global veriable directly
+Or you can change the `vim.g.scratch_config` global variable directly
 
 </details>
 
-## Commands & Keymapps
+## Commands & Keymaps
 
 All commands are started with `Scratch`, and no default keymappings.
 
@@ -100,7 +104,11 @@ All commands are started with `Scratch`, and no default keymappings.
 | `ScratchOpen`     | Opens an existing scratch file from the `scratch_file_dir`.                                             |
 | `ScratchOpenFzf`  | Uses fuzzy finding to search through the contents of scratch files and open a selected file.            |
 
-Keybinding recommandation:
+### Snacks multi mode
+
+When using the snacks picker, you can set `picker_snacks_multi = true` to open `ScratchOpen` in multi mode, which combines file search and content grep in a single picker. `ScratchOpenFzf` is unaffected by this setting. You can toggle back to the classic file-only view at any time with `<C-f>` (or your custom `picker_keys.toggle_mode` key).
+
+Keybinding recommendation:
 
 ```lua
 vim.keymap.set("n", "<M-C-n>", "<cmd>Scratch<cr>")

--- a/README.md
+++ b/README.md
@@ -43,8 +43,16 @@ return {
           subdir = "project-name" -- group scratch files under specific sub folder
         },
         ["yaml"] = {},
+        py = {
+          subdir = "python-scripts/%" -- group scratch files under path with random generated subdirectory
+          content = { "#!/usr/bin/env python3", "", "" },
+          cursor = {
+            location = { 3, 0 },
+            insert_mode = false,
+          },
+        },
         go = {
-          subdir = "unique", -- isolate each scratch file in its own subdirectory
+          subdir = true, -- isolate each scratch file in its own subdirectory
           filename = "main", -- the filename of the scratch file in the subdirectory
           content = { "package main", "", "func main() {", "  ", "}" },
           cursor = {

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ return {
     require("scratch").setup({
       scratch_file_dir = vim.fn.stdpath("cache") .. "/scratch.nvim", -- where your scratch files will be put
       window_cmd = "edit", -- 'vsplit' | 'split' | 'edit' | 'tabedit' | 'rightbelow vsplit'
-      -- fzf-lua is recommended, since it will order the files by modification datetime desc. (require rg)
-      -- snacks.nvim is also supported with files/grep/multi mode toggle (require rg)
+      -- fzf-lua it will order the files by modification datetime desc. (require rg)
+      -- snacks.nvim is also supported with files/grep/multi mode toggle and orders by datetime desc. (require rg)
       file_picker = "fzflua", -- "fzflua" | "telescope" | "snacks" | nil
       filetypes = { "lua", "js", "sh", "ts" }, -- you can simply put filetype here
       filetype_details = { -- or, you can have more control here

--- a/lua/scratch/api.lua
+++ b/lua/scratch/api.lua
@@ -235,10 +235,119 @@ local function open_scratch_snacks(initial_mode, current_mode)
     return
   end
 
-  -- PLACEHOLDER: full implementation in next commit
-  snacks.picker.files({
-    cwd = vim.g.scratch_config.scratch_file_dir,
-  })
+  local cfg = vim.g.scratch_config
+  local keys = cfg.picker_keys or {}
+  local cwd = cfg.scratch_file_dir
+  local mode = current_mode or initial_mode
+
+  local titles =
+    { files = "Scratch [files]", grep = "Scratch [content]", multi = "Scratch [multi]" }
+
+  local function picker_config_for_mode(m)
+    if m == "multi" then
+      return {
+        finder = function(opts, ctx)
+          local files_mod = require("snacks.picker.source.files")
+          local grep_mod = require("snacks.picker.source.grep")
+
+          return function(cb)
+            -- Files: uses filter.search as glob for fd (empty = all files)
+            local files_result = files_mod.files(opts, ctx:clone())
+            if type(files_result) == "function" then
+              files_result(cb)
+            elseif type(files_result) == "table" then
+              for _, item in ipairs(files_result) do
+                cb(item)
+              end
+            end
+
+            -- Grep: uses filter.search as regex for rg (skip if empty)
+            if (ctx.filter.search or "") ~= "" then
+              local grep_result = grep_mod.grep(opts, ctx:clone())
+              if type(grep_result) == "function" then
+                grep_result(cb)
+              elseif type(grep_result) == "table" then
+                for _, item in ipairs(grep_result) do
+                  cb(item)
+                end
+              end
+            end
+          end
+        end,
+        live = true,
+        supports_live = true,
+        matcher = { sort_empty = true, frecency = true },
+      }
+    elseif m == "grep" then
+      return { finder = "grep", live = true, supports_live = true }
+    else
+      return { finder = "files", live = false, supports_live = false }
+    end
+  end
+
+  local mode_cfg = picker_config_for_mode(mode)
+
+  local picker_opts = vim.tbl_extend("force", {
+    source = "scratch",
+    title = titles[mode],
+    cwd = cwd,
+    format = "file",
+    preview = "file",
+    show_empty = true,
+    confirm = function(picker, item, action)
+      require("snacks.picker.actions").jump(picker, item, action)
+      if item and item.pos then
+        vim.fn.setreg("/", picker.input.filter.search or "")
+      end
+    end,
+    actions = {
+      toggle_mode = function(picker)
+        if initial_mode == "multi" then
+          if mode == "multi" then
+            mode = "files"
+          elseif mode == "files" then
+            mode = "grep"
+          else
+            mode = "multi"
+          end
+        else
+          mode = mode == "grep" and "files" or "grep"
+        end
+        picker:close()
+        vim.schedule(function()
+          open_scratch_snacks(initial_mode, mode)
+        end)
+      end,
+      delete_file = function(picker, item)
+        if not item or not item.file then
+          utils.log_err("No file selected to delete")
+          return
+        end
+        local name = vim.fn.fnamemodify(item.file, ":t")
+        vim.ui.input({ prompt = "Delete " .. name .. "? (y/n) " }, function(input)
+          if input == "y" then
+            local abs = item.cwd and (item.cwd .. slash .. item.file) or item.file
+            utils.remove_file_and_empty_parents(abs, cwd)
+            picker:find({ refresh = true })
+          end
+        end)
+      end,
+    },
+    win = {
+      input = {
+        keys = {
+          [keys.delete or "<C-x>"] = { "delete_file", mode = { "n" }, desc = "Delete scratch file" },
+          [keys.toggle_mode or "<C-f>"] = {
+            "toggle_mode",
+            mode = { "i", "n" },
+            desc = "Toggle content/file search",
+          },
+        },
+      },
+    },
+  }, mode_cfg)
+
+  snacks.picker(picker_opts)
 end
 
 local function open_scratch_vim_ui()

--- a/lua/scratch/api.lua
+++ b/lua/scratch/api.lua
@@ -281,7 +281,12 @@ local function open_scratch_snacks(initial_mode, current_mode)
     elseif m == "grep" then
       return { finder = "grep", live = true, supports_live = true }
     else
-      return { finder = "files", live = false, supports_live = false }
+      return {
+        finder = "files",
+        live = false,
+        supports_live = false,
+        matcher = { sort_empty = true },
+      }
     end
   end
 
@@ -294,6 +299,13 @@ local function open_scratch_snacks(initial_mode, current_mode)
     format = "file",
     preview = "file",
     show_empty = true,
+    sort = { fields = { "score:desc", "mtime:desc", "idx" } },
+    transform = function(item)
+      local path = item.cwd and (item.cwd .. slash .. item.file) or item.file
+      if path then
+        item.mtime = utils.get_file_mtime(path)
+      end
+    end,
     confirm = function(picker, item, action)
       require("snacks.picker.actions").jump(picker, item, action)
       if item and item.pos then
@@ -324,13 +336,11 @@ local function open_scratch_snacks(initial_mode, current_mode)
           return
         end
         local name = vim.fn.fnamemodify(item.file, ":t")
-        vim.ui.input({ prompt = "Delete " .. name .. "? (y/n) " }, function(input)
-          if input == "y" then
-            local abs = item.cwd and (item.cwd .. slash .. item.file) or item.file
-            utils.remove_file_and_empty_parents(abs, cwd)
-            picker:find({ refresh = true })
-          end
-        end)
+        if vim.fn.confirm("Delete " .. name .. "?", "&Yes\n&No", 2) == 1 then
+          local abs = item.cwd and (item.cwd .. slash .. item.file) or item.file
+          utils.remove_file_and_empty_parents(abs, cwd)
+          picker:find({ refresh = true })
+        end
       end,
     },
     win = {

--- a/lua/scratch/api.lua
+++ b/lua/scratch/api.lua
@@ -1,13 +1,14 @@
 local config = require("scratch.config")
-local slash = require("scratch.utils").Slash()
 local utils = require("scratch.utils")
-local telescope_status, telescope_builtin = pcall(require, "telescope.builtin")
+local slash = utils.Slash()
 local Hooks = require("scratch.hooks")
 local MANUAL_INPUT_OPTION = "MANUAL_INPUT"
 
 ---@class Scratch.ActionOpts
 ---@field window_cmd? Scratch.WindowCmd
 ---@field content? string[] content will be put into the scratch file
+---@field config_data? Scratch.Config
+---@field ft? string
 
 ---@param abs_path string
 ---@param opts? Scratch.ActionOpts
@@ -18,17 +19,26 @@ local function create_and_edit_file(abs_path, opts)
     vim.fn.mkdir(parent_dir, "p")
   end
 
-  local cmd = (opts and opts.window_cmd) or vim.g.scratch_config.window_cmd or "edit"
+  local config_data = opts and opts.config_data or vim.g.scratch_config
+  local cmd = (opts and opts.window_cmd) or config_data.window_cmd or "edit"
   if cmd == "popup" then
     utils.new_popup_window(abs_path)
-    vim.cmd("w " .. abs_path)
+    vim.cmd("w " .. vim.fn.fnameescape(abs_path))
   else
-    vim.api.nvim_command(cmd .. " " .. abs_path)
+    vim.api.nvim_command(cmd .. " " .. vim.fn.fnameescape(abs_path))
   end
 
-  local hooks = Hooks.get_hooks(vim.g.scratch_config.hooks, Hooks.trigger_points.AFTER)
+  local hooks = Hooks.get_hooks(config_data.hooks, Hooks.trigger_points.AFTER)
   for _, hook in ipairs(hooks) do
-    hook.callback()
+    local ok, err = pcall(
+      hook.callback,
+      { abs_path = abs_path, ft = opts and opts.ft, bufnr = vim.api.nvim_get_current_buf() }
+    )
+    if not ok then
+      utils.log_err(
+        "Hook" .. (hook.name and (" '" .. hook.name .. "'") or "") .. " failed: " .. tostring(err)
+      )
+    end
   end
 end
 
@@ -39,15 +49,16 @@ end
 
 ---@param filename string
 local function createScratchFileByName(filename)
-  local config_data = vim.g.scratch_config
-  local scratch_file_dir = config_data.scratch_file_dir
+  local cfg = vim.g.scratch_config
+  local scratch_file_dir = cfg.scratch_file_dir
 
   local fullpath = scratch_file_dir .. slash .. filename
-  create_and_edit_file(fullpath)
+  create_and_edit_file(fullpath, { config_data = cfg })
 end
 
-local function register_local_key()
-  local localKeys = vim.g.scratch_config.localKeys
+---@param config_data Scratch.Config
+local function register_local_key(config_data)
+  local localKeys = config_data.localKeys
   if localKeys and #localKeys > 0 then
     for _, key in ipairs(localKeys) do
       for _, namePattern in ipairs(key.filenameContains) do
@@ -65,21 +76,21 @@ local function write_default_content(ft, opts)
   if opts and opts.content then
     write_lines_to_buffer(opts.content)
   else
-    local config_data = vim.g.scratch_config
+    local config_data = opts and opts.config_data or vim.g.scratch_config
 
     local has_default_content = config_data.filetype_details[ft]
       and config_data.filetype_details[ft].content
       and #config_data.filetype_details[ft].content > 0
 
     if has_default_content then
-      write_lines_to_buffer(vim.g.scratch_config.filetype_details[ft].content)
+      write_lines_to_buffer(config_data.filetype_details[ft].content)
     end
   end
 end
 
----@type Scratch.Action
-local function put_cursor(ft)
-  local config_data = vim.g.scratch_config
+---@param ft string
+---@param config_data Scratch.Config
+local function put_cursor(ft, config_data)
   local has_cursor_position = config_data.filetype_details[ft]
     and config_data.filetype_details[ft].cursor
     and #config_data.filetype_details[ft].cursor.location > 0
@@ -95,52 +106,57 @@ end
 ---@param ft string
 ---@param opts? Scratch.ActionOpts
 local function createScratchFileByType(ft, opts)
-  local abs_path = config.get_abs_path(ft)
+  local cfg = vim.g.scratch_config
+  local merged = vim.tbl_extend("force", opts or {}, { config_data = cfg, ft = ft })
 
-  create_and_edit_file(abs_path, opts)
-  write_default_content(ft, opts)
-  put_cursor(ft)
-  register_local_key()
+  local abs_path = config.get_abs_path(ft, cfg)
+
+  create_and_edit_file(abs_path, merged)
+  write_default_content(ft, merged)
+  put_cursor(ft, cfg)
+  register_local_key(cfg)
 end
 
+---@param config_data Scratch.Config
 ---@return string[]
-local function get_all_filetypes()
-  local config_data = vim.g.scratch_config
+local function get_all_filetypes(config_data)
+  local seen = {}
   local combined_filetypes = {}
   for _, ft in ipairs(config_data.filetypes or {}) do
-    if not vim.tbl_contains(combined_filetypes, ft) then
-      table.insert(combined_filetypes, ft)
+    if not seen[ft] then
+      seen[ft] = true
+      combined_filetypes[#combined_filetypes + 1] = ft
     end
   end
-
   for ft, _ in pairs(config_data.filetype_details or {}) do
-    if not vim.tbl_contains(combined_filetypes, ft) then
-      table.insert(combined_filetypes, ft)
+    if not seen[ft] then
+      seen[ft] = true
+      combined_filetypes[#combined_filetypes + 1] = ft
     end
   end
-
-  table.insert(combined_filetypes, MANUAL_INPUT_OPTION)
+  combined_filetypes[#combined_filetypes + 1] = MANUAL_INPUT_OPTION
   return combined_filetypes
 end
 
 ---@param func Scratch.Action
 ---@param opts? Scratch.ActionOpts
 local function select_filetype_then_do(func, opts)
-  local filetypes = get_all_filetypes()
+  local cfg = vim.g.scratch_config
+  local filetypes = get_all_filetypes(cfg)
 
   vim.ui.select(filetypes, {
     prompt = "Select filetype",
     format_item = function(item)
       return item
     end,
-  }, function(choosedFt)
-    if choosedFt then
-      if choosedFt == MANUAL_INPUT_OPTION then
+  }, function(chosen_ft)
+    if chosen_ft then
+      if chosen_ft == MANUAL_INPUT_OPTION then
         vim.ui.input({ prompt = "Input filetype: " }, function(ft)
           func(ft, opts)
         end)
       else
-        func(choosedFt, opts)
+        func(chosen_ft, opts)
       end
     end
   end)

--- a/lua/scratch/api.lua
+++ b/lua/scratch/api.lua
@@ -162,13 +162,11 @@ local function select_filetype_then_do(func, opts)
   end)
 end
 
-local function get_scratch_files()
-  local config_data = vim.g.scratch_config
-  local scratch_file_dir = config_data.scratch_file_dir
+local function get_scratch_files(scratch_dir)
+  local entries = utils.list_scratch_files(scratch_dir)
   local res = {}
-  res = utils.listDirectoryRecursive(scratch_file_dir)
-  for i, str in ipairs(res) do
-    res[i] = string.sub(str, string.len(scratch_file_dir) + 2)
+  for _, entry in ipairs(entries) do
+    res[#res + 1] = entry.path:sub(#scratch_dir + 2)
   end
   return res
 end
@@ -192,74 +190,70 @@ local function open_scratch_fzflua()
   local ok, fzf_lua = pcall(require, "fzf-lua")
   if not ok then
     utils.log_err("Can't find fzf-lua, please check your configuration")
+    return
   end
 
   if vim.fn.executable("rg") ~= 1 then
     utils.log_err("Can't find rg executable, please check your configuration")
+    return
   end
-  fzf_lua.files({ cmd = "rg --files --sortr modified " .. vim.g.scratch_config.scratch_file_dir })
+  local cfg = vim.g.scratch_config
+  fzf_lua.files({ cmd = "rg --files --sortr modified " .. vim.fn.shellescape(cfg.scratch_file_dir) })
 end
 
 local function open_scratch_telescope()
-  local config_data = vim.g.scratch_config
-
-  if not telescope_status then
+  local ok, telescope_builtin = pcall(require, "telescope.builtin")
+  if not ok then
     vim.notify(
-      'ScrachOpen needs telescope.nvim or you can just add `"use_telescope: false"` into your config file ot use native select ui'
+      'ScratchOpen needs telescope.nvim or you can set file_picker to "fzflua", "snacks", or nil to use native select ui'
     )
     return
   end
 
+  local config_data = vim.g.scratch_config
+  local keys = config_data.picker_keys or {}
+  local delete_key = keys.delete or "<C-x>"
+
   telescope_builtin.find_files({
     cwd = config_data.scratch_file_dir,
     attach_mappings = function(prompt_bufnr, map)
-      -- TODO: user can customise keybinding
-      map("n", "dd", function()
+      map("n", delete_key, function()
         require("scratch.telescope_actions").delete_item(prompt_bufnr)
       end)
-
       return true
     end,
   })
 end
 
-local function open_scratch_snacks()
+--- Open a snacks picker for scratch files.
+---@param initial_mode "files"|"grep"|"multi"
+---@param current_mode? "files"|"grep"|"multi"
+local function open_scratch_snacks(initial_mode, current_mode)
   local ok, snacks = pcall(require, "snacks")
   if not ok then
     utils.log_err("Can't find snacks.nvim, please check your configuration")
     return
   end
 
-  -- Check if rg is available
-  if vim.fn.executable("rg") ~= 1 then
-    utils.log_err("Can't find rg executable, please check your configuration")
-    -- Fallback to default snacks behavior
-    snacks.picker.files({
-      cwd = vim.g.scratch_config.scratch_file_dir,
-      prompt = "Scratch Files",
-    })
-    return
-  end
-
-  -- Use rg with sorting by modified time
+  -- PLACEHOLDER: full implementation in next commit
   snacks.picker.files({
-    cmd = "rg",
-    args = { "--files", "--sortr", "modified" },
     cwd = vim.g.scratch_config.scratch_file_dir,
-    prompt = "Scratch Files",
   })
 end
 
 local function open_scratch_vim_ui()
-  local files = get_scratch_files()
-  local config_data = vim.g.scratch_config
+  local cfg = vim.g.scratch_config
+  local scratch_file_dir = cfg.scratch_file_dir
+  local files = get_scratch_files(scratch_file_dir)
 
-  local scratch_file_dir = config_data.scratch_file_dir
+  -- Pre-compute modification times for O(n) instead of O(n log n) getftime calls
+  local mtimes = {}
+  for _, f in ipairs(files) do
+    mtimes[f] = vim.fn.getftime(scratch_file_dir .. slash .. f)
+  end
 
-  -- sort the files by their last modified time in descending order
   table.sort(files, function(a, b)
-    return vim.fn.getftime(scratch_file_dir .. slash .. a)
-      > vim.fn.getftime(scratch_file_dir .. slash .. b)
+    return mtimes[a] > mtimes[b]
   end)
 
   vim.ui.select(files, {
@@ -269,8 +263,8 @@ local function open_scratch_vim_ui()
     end,
   }, function(chosenFile)
     if chosenFile then
-      create_and_edit_file(scratch_file_dir .. slash .. chosenFile)
-      register_local_key()
+      create_and_edit_file(scratch_file_dir .. slash .. chosenFile, { config_data = cfg })
+      register_local_key(cfg)
     end
   end)
 end
@@ -283,7 +277,7 @@ local function openScratch()
   elseif config_data.file_picker == "fzflua" then
     open_scratch_fzflua()
   elseif config_data.file_picker == "snacks" then
-    open_scratch_snacks()
+    open_scratch_snacks(config_data.picker_snacks_multi and "multi" or "files")
   else
     open_scratch_vim_ui()
   end
@@ -291,14 +285,31 @@ end
 
 local function fzfScratch()
   local config_data = vim.g.scratch_config
-  if not telescope_status then
-    vim.notify("ScrachOpenFzf needs telescope.nvim")
-    return
-  end
+  local scratch_dir = config_data.scratch_file_dir
 
-  telescope_builtin.live_grep({
-    cwd = config_data.scratch_file_dir,
-  })
+  if config_data.file_picker == "snacks" then
+    open_scratch_snacks("grep")
+  elseif config_data.file_picker == "fzflua" then
+    local ok, fzf_lua = pcall(require, "fzf-lua")
+    if not ok then
+      utils.log_err("Can't find fzf-lua, please check your configuration")
+      return
+    end
+    if vim.fn.executable("rg") ~= 1 then
+      utils.log_err("Can't find rg executable, please check your configuration")
+      return
+    end
+    fzf_lua.live_grep({ cwd = scratch_dir })
+  elseif config_data.file_picker == "telescope" then
+    local ok, telescope_builtin = pcall(require, "telescope.builtin")
+    if not ok then
+      utils.log_err("ScratchOpenFzf needs telescope.nvim")
+      return
+    end
+    telescope_builtin.live_grep({ cwd = scratch_dir })
+  else
+    open_scratch_vim_ui()
+  end
 end
 
 return {

--- a/lua/scratch/config.lua
+++ b/lua/scratch/config.lua
@@ -100,25 +100,24 @@ local function setup(user_config)
 end
 
 ---@param ft string
+---@param config_data Scratch.Config
 ---@return string
-local function get_abs_path(ft)
-  local config_data = vim.g.scratch_config
+local function get_abs_path(ft, config_data)
+  local detail = config_data.filetype_details[ft]
 
-  local filename = config_data.filetype_details[ft] and config_data.filetype_details[ft].filename
+  local filename = (detail and detail.filename)
     or tostring(os.date("%y-%m-%d_%H-%M-%S")) .. "." .. ft
 
   local parentDir = config_data.scratch_file_dir
-  local subdir = config_data.filetype_details[ft] and config_data.filetype_details[ft].subdir
-  if subdir ~= nil then
+  local subdir = detail and detail.subdir
+  local needs_unique = subdir == "unique" or (detail and detail.requireDir) or false
+
+  if subdir and subdir ~= "unique" then
     parentDir = parentDir .. slash .. subdir
   end
   vim.fn.mkdir(parentDir, "p")
 
-  local require_dir = config_data.filetype_details[ft]
-      and config_data.filetype_details[ft].requireDir
-    or false
-
-  return utils.genFilepath(filename, parentDir, require_dir)
+  return utils.genFilepath(filename, parentDir, needs_unique)
 end
 
 return {

--- a/lua/scratch/config.lua
+++ b/lua/scratch/config.lua
@@ -28,8 +28,8 @@ local slash = utils.Slash()
 
 ---@class Scratch.FiletypeDetail
 ---@field filename? string
----@field requireDir? boolean -- DEPRECATED: use subdir = "unique" instead
----@field subdir? string -- subdirectory name, or "unique" for per-file isolation
+---@field requireDir? boolean -- DEPRECATED: use subdir = true instead
+---@field subdir? string|boolean -- subdirectory path, true for unique, "%" in path for unique segment
 ---@field content? string[]
 ---@field cursor? Scratch.Cursor
 --
@@ -80,7 +80,7 @@ local function setup(user_config)
       vim.notify(
         "[scratch.nvim] filetype_details."
           .. ft
-          .. '.requireDir is deprecated. Use subdir = "unique" instead.',
+          .. '.requireDir is deprecated. Use subdir = true | "example-dir/%" instead.',
         vim.log.levels.WARN
       )
     end
@@ -109,14 +109,22 @@ local function get_abs_path(ft, config_data)
     or tostring(os.date("%y-%m-%d_%H-%M-%S")) .. "." .. ft
 
   local parentDir = config_data.scratch_file_dir
-  local subdir = detail and detail.subdir
-  local needs_unique = subdir == "unique" or (detail and detail.requireDir) or false
+  local needs_unique = false
 
-  if subdir and subdir ~= "unique" then
-    parentDir = parentDir .. slash .. subdir
+  if detail then
+    local subdir = detail.subdir
+    if detail.requireDir or subdir == true then
+      needs_unique = true
+    elseif type(subdir) == "string" then
+      if subdir:find("%%") then
+        parentDir = parentDir .. slash .. subdir:gsub("%%", utils.genUniqueDirName())
+      else
+        parentDir = parentDir .. slash .. subdir
+      end
+    end
   end
-  vim.fn.mkdir(parentDir, "p")
 
+  vim.fn.mkdir(parentDir, "p")
   return utils.genFilepath(filename, parentDir, needs_unique)
 end
 

--- a/lua/scratch/config.lua
+++ b/lua/scratch/config.lua
@@ -1,5 +1,5 @@
-local slash = require("scratch.utils").Slash()
 local utils = require("scratch.utils")
+local slash = utils.Slash()
 
 ---@alias mode
 ---| '"n"'
@@ -28,13 +28,17 @@ local utils = require("scratch.utils")
 
 ---@class Scratch.FiletypeDetail
 ---@field filename? string
----@field requireDir? boolean -- TODO: conbine requireDir and subdir into one table
----@field subdir? string
+---@field requireDir? boolean -- DEPRECATED: use subdir = "unique" instead
+---@field subdir? string -- subdirectory name, or "unique" for per-file isolation
 ---@field content? string[]
 ---@field cursor? Scratch.Cursor
 --
 ---@class Scratch.FiletypeDetails
 ---@field [string] Scratch.FiletypeDetail
+
+---@class Scratch.PickerKeys
+---@field delete? string
+---@field toggle_mode? string
 
 ---@class Scratch.Config
 ---@field scratch_file_dir string
@@ -44,6 +48,8 @@ local utils = require("scratch.utils")
 ---@field filetype_details Scratch.FiletypeDetails
 ---@field localKeys Scratch.LocalKeyConfig[]
 ---@field hooks Scratch.Hook[]
+---@field picker_keys? Scratch.PickerKeys
+---@field picker_snacks_multi? boolean
 local default_config = {
   scratch_file_dir = vim.fn.stdpath("cache") .. slash .. "scratch.nvim", -- where your scratch files will be put
   filetypes = { "lua", "js", "py", "sh" }, -- you can simply put filetype here
@@ -52,6 +58,11 @@ local default_config = {
   filetype_details = {},
   localKeys = {},
   hooks = {},
+  picker_keys = {
+    delete = "<C-x>",
+    toggle_mode = "<C-f>",
+  },
+  picker_snacks_multi = false,
 }
 
 ---@type Scratch.Config
@@ -62,7 +73,30 @@ local function setup(user_config)
   user_config = user_config or {}
 
   vim.g.scratch_config = vim.tbl_deep_extend("force", default_config, user_config or {})
-    or default_config
+
+  -- Warn about deprecated requireDir
+  for ft, detail in pairs(vim.g.scratch_config.filetype_details or {}) do
+    if detail.requireDir then
+      vim.notify(
+        "[scratch.nvim] filetype_details."
+          .. ft
+          .. '.requireDir is deprecated. Use subdir = "unique" instead.',
+        vim.log.levels.WARN
+      )
+    end
+  end
+
+  -- Validate file_picker
+  local cfg = vim.g.scratch_config
+  local valid_pickers = { fzflua = true, telescope = true, snacks = true }
+  if cfg.file_picker and not valid_pickers[cfg.file_picker] then
+    vim.notify(
+      '[scratch.nvim] Invalid file_picker "'
+        .. cfg.file_picker
+        .. '". Valid options: "fzflua", "telescope", "snacks", or nil.',
+      vim.log.levels.WARN
+    )
+  end
 end
 
 ---@param ft string

--- a/lua/scratch/hooks.lua
+++ b/lua/scratch/hooks.lua
@@ -1,7 +1,7 @@
 local M = {}
 
 ---@class Scratch.Hook
----@field callback fun(param: table?)
+---@field callback fun(ctx: {abs_path: string, ft: string?, bufnr: integer}?)
 ---@field name? string
 ---@field trigger_point? string
 

--- a/lua/scratch/telescope_actions.lua
+++ b/lua/scratch/telescope_actions.lua
@@ -1,39 +1,19 @@
 local M = {}
 
-local action_state = require("telescope.actions.state")
-local Path = require("plenary").path
-local config = require("scratch.config")
 local utils = require("scratch.utils")
 
--- TODO: register buffer local key
 function M.delete_item(prompt_bufnr)
-  local _delelte = function(p)
-    local flag = false
-    while p:exists() do
-      local f = os.remove(p.filename)
-      if f then
-        flag = true
-        vim.notify("delete " .. p.filename)
-      else
-        break
-      end
-      p = p:parent()
-    end
-    return flag
-  end
-
+  local action_state = require("telescope.actions.state")
   local picker = action_state.get_current_picker(prompt_bufnr)
   picker:delete_selection(function(s)
     local file_name = s[1]
-    -- INFO: currently just protect configFilePath from being removed
-    if file_name == "configFilePath" then
-      vim.notify("[scratch.nvim] configFilePath cannot be removed", vim.log.levels.WARN)
-      return false
+    local scratch_file_dir = vim.g.scratch_config.scratch_file_dir
+    local full_path = scratch_file_dir .. utils.Slash() .. file_name
+    if vim.fn.filereadable(full_path) == 1 then
+      utils.remove_file_and_empty_parents(full_path, scratch_file_dir)
+      return true
     end
-    local config_data = config.getConfig()
-    local scratch_file_dir = config_data.scratch_file_dir
-    local p = Path:new({ scratch_file_dir, file_name, sep = utils.Slash() })
-    return _delelte(p)
+    return false
   end)
 end
 

--- a/lua/scratch/utils.lua
+++ b/lua/scratch/utils.lua
@@ -9,6 +9,11 @@ end
 local slash = Slash()
 local uv = vim.uv or vim.loop
 
+---@return string
+local function genUniqueDirName()
+  return os.date("%y%m%d%H%M%S") .. "-" .. string.format("%04x", math.random(0, 0xFFFF))
+end
+
 --- generate abs filepath
 ---@param filename string
 ---@param parentDir string
@@ -16,7 +21,7 @@ local uv = vim.uv or vim.loop
 ---@return string
 local function genFilepath(filename, parentDir, requiresDir)
   if requiresDir then
-    local dirName = os.date("%y%m%d%H%M%S") .. "-" .. string.format("%04x", math.random(0, 0xFFFF))
+    local dirName = genUniqueDirName()
     vim.fn.mkdir(parentDir .. slash .. dirName, "p")
     return parentDir .. slash .. dirName .. slash .. filename
   else
@@ -177,6 +182,7 @@ end
 return {
   Slash = Slash,
   genFilepath = genFilepath,
+  genUniqueDirName = genUniqueDirName,
   setLocalKeybindings = setLocalKeybindings,
   filenameContains = filenameContains,
   getSelectedText = getSelectedText,

--- a/lua/scratch/utils.lua
+++ b/lua/scratch/utils.lua
@@ -88,36 +88,18 @@ local function new_popup_window(title)
     relative = "editor", -- Assuming you want the floating window relative to the editor
     row = 2,
     col = 5,
-    width = vim.o.columns - 10, -- Get the screen width
-    height = vim.o.lines - 5, -- Get the screen height
+    width = vim.o.columns - 10,
+    height = vim.o.lines - 5,
     style = "minimal",
     border = "single",
     title = title,
   }
 
   local win = vim.api.nvim_open_win(popup_buf, true, opts)
-  --- Remove a file and clean up empty parent directories up to (not including) stop_dir
----@param filepath string
----@param stop_dir string
-local function remove_file_and_empty_parents(filepath, stop_dir)
-  local ok, err = os.remove(filepath)
-  if not ok then
-    vim.notify(
-      "scratch.nvim: failed to delete " .. filepath .. ": " .. tostring(err),
-      vim.log.levels.WARN
-    )
-    return
-  end
-  local dir = vim.fn.fnamemodify(filepath, ":h")
-  while dir ~= stop_dir and dir ~= "/" do
-    local entries = vim.fn.readdir(dir)
-    if entries and #entries == 0 then
-      vim.fn.delete(dir, "d")
-      dir = vim.fn.fnamemodify(dir, ":h")
-    else
-      break
-    end
-  end
+  return {
+    buf = popup_buf,
+    win = win,
+  }
 end
 
 --- Recursively list files with sortable timestamp keys
@@ -152,10 +134,28 @@ local function list_scratch_files(dir)
   return files
 end
 
-return {
-    buf = popup_buf,
-    win = win,
-  }
+--- Remove a file and clean up empty parent directories up to (not including) stop_dir
+---@param filepath string
+---@param stop_dir string
+local function remove_file_and_empty_parents(filepath, stop_dir)
+  local ok, err = os.remove(filepath)
+  if not ok then
+    vim.notify(
+      "scratch.nvim: failed to delete " .. filepath .. ": " .. tostring(err),
+      vim.log.levels.WARN
+    )
+    return
+  end
+  local dir = vim.fn.fnamemodify(filepath, ":h")
+  while dir ~= stop_dir and dir ~= "/" do
+    local entries = vim.fn.readdir(dir)
+    if entries and #entries == 0 then
+      vim.fn.delete(dir, "d")
+      dir = vim.fn.fnamemodify(dir, ":h")
+    else
+      break
+    end
+  end
 end
 
 return {

--- a/lua/scratch/utils.lua
+++ b/lua/scratch/utils.lua
@@ -1,5 +1,3 @@
-local M = {}
-
 local function Slash()
   local slash = "/"
   if vim.fn.has("win32") == 1 then
@@ -68,14 +66,6 @@ local function filenameContains(substr)
   end
 end
 
-local table_length = function(T)
-  local count = 0
-  for _ in pairs(T) do
-    count = count + 1
-  end
-  return count
-end
-
 ---@return string[]
 local function getSelectedText(mark, selection_mode)
   local pos1 = vim.fn.getpos("v")
@@ -133,7 +123,6 @@ end
 
 return {
   Slash = Slash,
-  listDirectoryRecursive = listDirectoryRecursive,
   genFilepath = genFilepath,
   setLocalKeybindings = setLocalKeybindings,
   filenameContains = filenameContains,

--- a/lua/scratch/utils.lua
+++ b/lua/scratch/utils.lua
@@ -7,26 +7,7 @@ local function Slash()
 end
 
 local slash = Slash()
-
--- Recursively list all files in the specified directory
-local function listDirectoryRecursive(directory)
-  local files = {}
-  local dir_list = vim.fn.readdir(directory)
-
-  for _, file in ipairs(dir_list) do
-    local path = directory .. slash .. file
-    if vim.fn.isdirectory(path) == 1 and file ~= "." and file ~= ".." then
-      local subfiles = listDirectoryRecursive(path)
-      for _, subfile in ipairs(subfiles) do
-        files[#files + 1] = subfile
-      end
-    elseif vim.fn.isdirectory(path) == 0 then
-      files[#files + 1] = path
-    end
-  end
-
-  return files
-end
+local uv = vim.uv or vim.loop
 
 --- generate abs filepath
 ---@param filename string
@@ -35,7 +16,7 @@ end
 ---@return string
 local function genFilepath(filename, parentDir, requiresDir)
   if requiresDir then
-    local dirName = vim.trim(vim.fn.system("uuidgen"))
+    local dirName = os.date("%y%m%d%H%M%S") .. "-" .. string.format("%04x", math.random(0, 0xFFFF))
     vim.fn.mkdir(parentDir .. slash .. dirName, "p")
     return parentDir .. slash .. dirName .. slash .. filename
   else
@@ -115,7 +96,39 @@ local function new_popup_window(title)
   }
 
   local win = vim.api.nvim_open_win(popup_buf, true, opts)
-  return {
+  --- Recursively list files with sortable timestamp keys
+---@param dir string
+---@return {path: string, sort_key: string}[]
+local function list_scratch_files(dir)
+  local files = {}
+  local handle = uv.fs_scandir(dir)
+  if not handle then
+    return files
+  end
+  while true do
+    local name, typ = uv.fs_scandir_next(handle)
+    if not name then
+      break
+    end
+    local full = dir .. slash .. name
+    if typ == "directory" then
+      local sub = list_scratch_files(full)
+      for _, f in ipairs(sub) do
+        files[#files + 1] = f
+      end
+    else
+      local ts = name:match("^(%d%d%-%d%d%-%d%d_%d%d%-%d%d%-%d%d)")
+      if not ts then
+        local stat = uv.fs_stat(full)
+        ts = stat and os.date("%y-%m-%d_%H-%M-%S", stat.mtime.sec) or "00-00-00_00-00-00"
+      end
+      files[#files + 1] = { path = full, sort_key = ts }
+    end
+  end
+  return files
+end
+
+return {
     buf = popup_buf,
     win = win,
   }
@@ -129,4 +142,5 @@ return {
   getSelectedText = getSelectedText,
   log_err = log_err,
   new_popup_window = new_popup_window,
+  list_scratch_files = list_scratch_files,
 }

--- a/lua/scratch/utils.lua
+++ b/lua/scratch/utils.lua
@@ -96,7 +96,31 @@ local function new_popup_window(title)
   }
 
   local win = vim.api.nvim_open_win(popup_buf, true, opts)
-  --- Recursively list files with sortable timestamp keys
+  --- Remove a file and clean up empty parent directories up to (not including) stop_dir
+---@param filepath string
+---@param stop_dir string
+local function remove_file_and_empty_parents(filepath, stop_dir)
+  local ok, err = os.remove(filepath)
+  if not ok then
+    vim.notify(
+      "scratch.nvim: failed to delete " .. filepath .. ": " .. tostring(err),
+      vim.log.levels.WARN
+    )
+    return
+  end
+  local dir = vim.fn.fnamemodify(filepath, ":h")
+  while dir ~= stop_dir and dir ~= "/" do
+    local entries = vim.fn.readdir(dir)
+    if entries and #entries == 0 then
+      vim.fn.delete(dir, "d")
+      dir = vim.fn.fnamemodify(dir, ":h")
+    else
+      break
+    end
+  end
+end
+
+--- Recursively list files with sortable timestamp keys
 ---@param dir string
 ---@return {path: string, sort_key: string}[]
 local function list_scratch_files(dir)
@@ -143,4 +167,5 @@ return {
   log_err = log_err,
   new_popup_window = new_popup_window,
   list_scratch_files = list_scratch_files,
+  remove_file_and_empty_parents = remove_file_and_empty_parents,
 }

--- a/lua/scratch/utils.lua
+++ b/lua/scratch/utils.lua
@@ -95,7 +95,7 @@ end
 
 ---@param msg string
 local function log_err(msg)
-  vim.notify(msg, vim.log.levels.ERROR, { title = "easy-commands.nvim" })
+  vim.notify(msg, vim.log.levels.ERROR, { title = "scratch.nvim" })
 end
 
 ---@param title string
@@ -107,11 +107,11 @@ local function new_popup_window(title)
     relative = "editor", -- Assuming you want the floating window relative to the editor
     row = 2,
     col = 5,
-    width = vim.api.nvim_get_option("columns") - 10, -- Get the screen width
-    height = vim.api.nvim_get_option("lines") - 5, -- Get the screen height
+    width = vim.o.columns - 10, -- Get the screen width
+    height = vim.o.lines - 5, -- Get the screen height
     style = "minimal",
     border = "single",
-    title = "",
+    title = title,
   }
 
   local win = vim.api.nvim_open_win(popup_buf, true, opts)

--- a/lua/scratch/utils.lua
+++ b/lua/scratch/utils.lua
@@ -102,9 +102,30 @@ local function new_popup_window(title)
   }
 end
 
---- Recursively list files with sortable timestamp keys
+--- Get file mtime as epoch seconds.
+--- Tries to parse timestamp from filename first (cheap), falls back to fs_stat.
+---@param filepath string absolute path
+---@return number mtime epoch seconds, 0 if unknown
+local function get_file_mtime(filepath)
+  local name = vim.fn.fnamemodify(filepath, ":t")
+  local yy, mm, dd, hh, mi, ss = name:match("^(%d%d)%-(%d%d)%-(%d%d)_(%d%d)%-(%d%d)%-(%d%d)")
+  if yy then
+    return os.time({
+      year = 2000 + tonumber(yy),
+      month = tonumber(mm),
+      day = tonumber(dd),
+      hour = tonumber(hh),
+      min = tonumber(mi),
+      sec = tonumber(ss),
+    })
+  end
+  local stat = uv.fs_stat(filepath)
+  return stat and stat.mtime.sec or 0
+end
+
+--- Recursively list files with sortable mtime keys
 ---@param dir string
----@return {path: string, sort_key: string}[]
+---@return {path: string, sort_key: number}[]
 local function list_scratch_files(dir)
   local files = {}
   local handle = uv.fs_scandir(dir)
@@ -123,12 +144,7 @@ local function list_scratch_files(dir)
         files[#files + 1] = f
       end
     else
-      local ts = name:match("^(%d%d%-%d%d%-%d%d_%d%d%-%d%d%-%d%d)")
-      if not ts then
-        local stat = uv.fs_stat(full)
-        ts = stat and os.date("%y-%m-%d_%H-%M-%S", stat.mtime.sec) or "00-00-00_00-00-00"
-      end
-      files[#files + 1] = { path = full, sort_key = ts }
+      files[#files + 1] = { path = full, sort_key = get_file_mtime(full) }
     end
   end
   return files
@@ -166,6 +182,7 @@ return {
   getSelectedText = getSelectedText,
   log_err = log_err,
   new_popup_window = new_popup_window,
+  get_file_mtime = get_file_mtime,
   list_scratch_files = list_scratch_files,
   remove_file_and_empty_parents = remove_file_and_empty_parents,
 }

--- a/plugin/scratch_plugin.lua
+++ b/plugin/scratch_plugin.lua
@@ -1,21 +1,15 @@
-local utils = require("scratch.utils")
 -- make sure this file is loaded only once
 if vim.g.loaded_scratch == 1 then
   return
 end
 vim.g.loaded_scratch = 1
 
--- create any global command that does not depend on user setup
--- usually it is better to define most commands/mappings in the setup function
--- Be careful to not overuse this file!
-
--- TODO: remove those requires
 local scratch_api = require("scratch.api")
-
 local scratch_main = require("scratch")
 scratch_main.setup()
 
 vim.api.nvim_create_user_command("Scratch", function(args)
+  local utils = require("scratch.utils")
   local mode = vim.api.nvim_get_mode().mode
   local opts
   if mode ~= "n" then


### PR DESCRIPTION

I've had my own implementation of the snacks picker and some other little improvements for a while now, finally got around to apply my changes to the current state of the project.

- Reworked the snacks picker to support toggling between file search, grep, and a combined multi mode via <C-f> (configurable).
- Set `picker_snacks_multi = true` to start in multi mode by default (with ScratchOpen).
- (snacks) Results are sorted by recency, it parses the timestamp from the filename first, falls back to fs_stat. 
- (snacks) Delete confirmation uses `vim.fn.confirm`.
- `ScratchOpenFzf` now works with all picker backends instead of being hardcoded to telescope.
- `picker_keys` config lets users rebind the delete and toggle keys.
                                                                                 
Some minor other things:
  - File listing shelled out to find/uuidgen, now replaced with uv.fs_scandir and a os.date + random hex combo, no external deps
  - Telescope delete depended on config.getConfig() which didn't exist (#52), rewrote it using a new remove_file_and_empty_parents util that also cleans up empty parent dirs
  - Hooks should now receive context (abs_path, ft, bufnr) and are pcall-wrapped so a bad hook doesn't take down file creation
  - `requireDir` still works but warns about deprecation, `subdir = true` or `subdir = "my-directory/%"` is the unified replacement, which combines a specified path with random generated subdirectory.
